### PR TITLE
add close method

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function (archive, opts) {
     }, opts))
     ds.once('listening', () => ds.join(swarmKey))
     ds.listen(0)
+    emitter.close = ds.close.bind(ds)
   }
   return emitter
 }

--- a/readme.md
+++ b/readme.md
@@ -42,3 +42,7 @@ Defaults from datland-swarm-defaults can also be overwritten:
   * `dns.server`: DNS server
   * `dns.domain`: DNS domain
   * `dht.bootstrap`: distributed hash table bootstrapping nodes
+
+### `sw.close(cb)`
+
+Leave the p2p swarm and close existing connections.


### PR DESCRIPTION
Closes https://github.com/karissa/hyperdrive-archive-swarm/issues/2

This PR isnt complete, yet. The `webrtc-swarm` module needs to have a close method added, and then it can be exported by this module.
