### PR TITLE
Prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function HyperdriveSwarm (archive, opts) {
   self.signalhub = opts.signalhub || DEFAULT_SIGNALHUB
   self.archive = archive
   self.browser = null
-  self.swarm = null
+  self.node = null
   if (!!rtc()) self._browser(self.swarmKey)
   if (process.versions.node) self._node(self.swarmKey)
 
@@ -31,6 +31,7 @@ HyperdriveSwarm.prototype._browser = function (swarmKey) {
   var self = this
   self.browser = webRTCSwarm(signalhub(swarmKey, self.signalhub))
   self.browser.on('peer', function (peer) {
+    self.emit('browser-connection', peer)
     peer.pipe(self.archive.replicate()).pipe(peer)
   })
   return self.browser
@@ -46,6 +47,10 @@ HyperdriveSwarm.prototype._node = function (swarmKey) {
     }
   }, opts))
 
+  swarm.on('connection', function (peer) {
+    self.emit('connection', peer)
+  })
+
   swarm.on('listening', function () {
     swarm.join(swarmKey)
   })
@@ -55,7 +60,7 @@ HyperdriveSwarm.prototype._node = function (swarmKey) {
   })
 
   swarm.listen(args.port || 3282)
-  self.swarm = swarm
+  self.node = swarm
   return swarm
 }
 

--- a/index.js
+++ b/index.js
@@ -14,11 +14,13 @@ function HyperdriveSwarm (archive, opts) {
 
   if (!opts) opts = {}
 
-  self.swarmKey = (opts.signalhubPrefix || 'dat-') + archive.discoveryKey
+  self.swarmKey = (opts.signalhubPrefix || 'dat-') + archive.discoveryKey.toString('hex')
+  console.log(self.swarmKey)
   self.signalhub = opts.signalhub || DEFAULT_SIGNALHUB
   self.archive = archive
   self.browser = null
   self.node = null
+  self.opts = opts
   if (!!rtc()) self._browser(self.swarmKey)
   if (process.versions.node) self._node(self.swarmKey)
 
@@ -45,7 +47,7 @@ HyperdriveSwarm.prototype._node = function (swarmKey) {
     stream: function (peer) {
       return self.archive.replicate()
     }
-  }, opts))
+  }, self.opts))
 
   swarm.on('connection', function (peer) {
     self.emit('connection', peer)
@@ -59,7 +61,7 @@ HyperdriveSwarm.prototype._node = function (swarmKey) {
     swarm.listen(0)
   })
 
-  swarm.listen(args.port || 3282)
+  swarm.listen(self.opts.port || 3282)
   self.node = swarm
   return swarm
 }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function HyperdriveSwarm (archive, opts) {
   self.browser = null
   self.node = null
   self.opts = opts
-  if (!!rtc()) self._browser()
+  if (opts.webrtc || !!rtc()) self._browser()
   if (process.versions.node) self._node()
 
   events.EventEmitter.call(this)
@@ -32,12 +32,14 @@ inherits(HyperdriveSwarm, events.EventEmitter)
 HyperdriveSwarm.prototype._browser = function () {
   var self = this
   var swarmKey = (self.opts.signalhubPrefix || 'dat-') + self.archive.discoveryKey.toString('hex')
-  self.browser = webRTCSwarm(signalhub(swarmKey, self.signalhub))
-  self.browser.on('peer', function (peer) {
+  self.browser = webRTCSwarm(signalhub(swarmKey, self.signalhub), {wrtc: self.opts.wrtc})
+  self.browser.on('peer', function (conn) {
+    var peer = self.archive.replicate()
     self.connections++
+    console.log(self.connections)
     peer.on('close', function () { self.connections-- })
     self.emit('connection', peer, {type: 'webrtc-swarm'})
-    pump(peer, self.archive.replicate(), peer)
+    pump(conn, peer, conn)
   })
   return self.browser
 }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ HyperdriveSwarm.prototype._browser = function () {
   self.browser.on('peer', function (peer) {
     self.connections++
     peer.on('close', function () { self.connections-- })
-    self.emit('browser-connection', peer)
+    self.emit('connection', peer, {type: 'webrtc-swarm'})
     pump(peer, self.archive.replicate(), peer)
   })
   return self.browser
@@ -56,7 +56,7 @@ HyperdriveSwarm.prototype._node = function () {
   swarm.on('connection', function (peer) {
     self.connections++
     peer.on('close', function () { self.connections-- })
-    self.emit('connection', peer)
+    self.emit('connection', peer, {type: 'discovery-swarm'})
   })
 
   swarm.on('listening', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperdrive-archive-swarm",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Join the p2p swarm for the given hyperdrive archive",
   "main": "index.js",
   "scripts": {},

--- a/readme.md
+++ b/readme.md
@@ -19,8 +19,17 @@ var drive = hyperdrive(memdb())
 var archive = drive.createArchive('ARCHIVE_KEY')
 
 var sw = swarm(archive)
-sw.on('peer', function (peer) {
+sw.on('connection', function (peer) {
   console.log('got', peer)
+  peer.on('close', function () {
+    console.log('peer disconnected')
+  }) 
+})
+sw.on('browser-connection', function (peer) {
+  console.log('got browser peer', peer)
+  peer.on('close', function () {
+    console.log('peer disconnected')
+  }) 
 })
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ var archive = drive.createArchive('ARCHIVE_KEY')
 var sw = swarm(archive)
 sw.on('connection', function (peer, type) {
   console.log('got', peer, type) // type is 'webrtc-swarm' or 'discovery-swarm'
+  console.log('connected to', sw.connections, 'peers')
   peer.on('close', function () {
     console.log('peer disconnected')
   }) 
@@ -34,6 +35,8 @@ Will use `discovery-swarm`, and `webrtc-swarm` whenever available to attempt to 
 ### `var sw = swarm(archive, opts)`
 
 Join the p2p swarm for the given hyperdrive archive. The return object, `sw`, is an event emitter that will emit a `peer` event with the peer information when a peer is found.
+
+Get number of currently active connections with ```sw.connections```.
 
 ##### Options
 

--- a/readme.md
+++ b/readme.md
@@ -19,21 +19,15 @@ var drive = hyperdrive(memdb())
 var archive = drive.createArchive('ARCHIVE_KEY')
 
 var sw = swarm(archive)
-sw.on('connection', function (peer) {
-  console.log('got', peer)
-  peer.on('close', function () {
-    console.log('peer disconnected')
-  }) 
-})
-sw.on('browser-connection', function (peer) {
-  console.log('got browser peer', peer)
+sw.on('connection', function (peer, type) {
+  console.log('got', peer, type) // type is 'webrtc-swarm' or 'discovery-swarm'
   peer.on('close', function () {
     console.log('peer disconnected')
   }) 
 })
 ```
 
-Will use `discovery-swarm`, `signalhub`, and `webrtc-swarm` whenever available to attempt to connect peers. Uses `datland-swarm-defaults` for peer introduction defaults on the server side, which can be overwritten (see below).
+Will use `discovery-swarm`, and `webrtc-swarm` whenever available to attempt to connect peers. Uses `datland-swarm-defaults` for peer introduction defaults on the server side, which can be overwritten (see below).
 
 ## API
 


### PR DESCRIPTION
This makes the hyperdrive-archive-swarm into a prototype instance that handles swarms internally, making it easier to get access to the underlying swarm prototypes and manage things like speed and peer size
