### PR TITLE
Fix webrtc option and add doc

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function HyperdriveSwarm (archive, opts) {
   self.browser = null
   self.node = null
   self.opts = opts
-  if (opts.webrtc || webRTCSwarm.WEBRTC_SUPPORT) self._browser()
+  if (opts.wrtc || webRTCSwarm.WEBRTC_SUPPORT) self._browser()
   if (process.versions.node) self._node()
 
   events.EventEmitter.call(this)

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ Get number of currently active connections with ```sw.connections```.
 
   * `signalhub`: the url of the signalhub.
   * `signalhubPrefix`: the prefix for the archive's signalhub key
+  * `wrtc`: a webrtc instance, e.g. electron-webrtc, if not natively supported
 
 Defaults from datland-swarm-defaults can also be overwritten:
 


### PR DESCRIPTION
Changed webrtc option to `wrtc` to be consistent with [webrtc swarm option](https://github.com/karissa/hyperdrive-archive-swarm/blob/master/index.js#L53).
