### PR TITLE
Update to hyperdrive 7.4.0 and add upload/download opts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "electron-webrtc": "^0.2.6",
-    "hyperdrive": "^6.2.2",
+    "hyperdrive": "^7.4.0",
     "memdb": "^1.3.1",
     "standard": "^7.1.2",
     "tape": "^4.6.0"

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@ Get number of currently active connections with ```sw.connections```.
   * `signalhub`: the url of the signalhub.
   * `signalhubPrefix`: the prefix for the archive's signalhub key
   * `wrtc`: a webrtc instance, e.g. electron-webrtc, if not natively supported
+  * `upload`: bool, upload data to the other peer?
+  * `download`: bool, download data from the other peer?
 
 Defaults from datland-swarm-defaults can also be overwritten:
 


### PR DESCRIPTION
Hey Karissa!

This adds the new `upload` and `download` opts that Mathius added in hyperdrive 7.4.0. It stores the options as `.uploading` and `.downloading` on the swarm object, so that I can change the option after creating the swarm.
