### PR TITLE
Add opts.wrtc to hybrid opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ function HyperdriveSwarm (archive, opts) {
           upload: this.uploading,
           download: this.downloading
         })
-      }
-    }, opts)
+      }),
+    wrtc: opts.wrtc
   }
 
   HybridSwarm.call(this, hybridOpts)


### PR DESCRIPTION
Fix #19. 

datland-swarm-defaults does not take a second argument so the other opts were being discarded. Right now `opts.wrtc` is the only other option we need in hybrid opts, this PR adds that.
