### PR TITLE
add other discovery swarm options

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,12 @@ function HyperdriveSwarm (archive, opts) {
           upload: self.uploading,
           download: self.downloading
         })
-      }
+      },
+      utp: opts.utp,
+      tcp: opts.tcp
     }),
-    wrtc: opts.wrtc
+    wrtc: opts.wrtc,
+    port: opts.port
   }
 
   HybridSwarm.call(this, hybridOpts)

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,9 @@ Get number of currently active connections with ```sw.connections```.
   * `wrtc`: a webrtc instance, e.g. electron-webrtc, if not natively supported
   * `upload`: bool, upload data to the other peer?
   * `download`: bool, download data from the other peer?
+  * `port`: port for discovery swarm
+  * `utp`: use utp in discovery swarm
+  * `tcp`: use tcp in discovery swarm
 
 Defaults from datland-swarm-defaults can also be overwritten:
 


### PR DESCRIPTION
Okay, I totally forgot the other discovery swarm options before.

This is definitely more junky now and not sure if this is how we want to specify options. The nice part about this though is that they are explicit in this module, so you don't have to track down other ones to see what options you can use (they aren't documented in any upstream module).

We might want to move port to the discovery option. But we need upstream change in hybrid-swarm for that.
