### PR TITLE
Remove on listening event

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,13 +22,12 @@ function HyperdriveSwarm (archive, opts) {
     utp: opts.utp,
     tcp: opts.tcp
   }))
-  this.swarm.on('listening', function () {
-    self.swarm.join(self.archive.discoveryKey)
-  })
 
-  this.swarm.listen(opts.port || 3282)
   this.swarm.once('error', function () {
     self.swarm.listen(0)
   })
+  this.swarm.listen(opts.port || 3282)
+  this.swarm.join(this.archive.discoveryKey)
+  
   return this.swarm
 }

--- a/index.js
+++ b/index.js
@@ -28,6 +28,6 @@ function HyperdriveSwarm (archive, opts) {
   })
   this.swarm.listen(opts.port || 3282)
   this.swarm.join(this.archive.discoveryKey)
-  
+
   return this.swarm
 }


### PR DESCRIPTION
* We don't need to wait for `on('listening')` because discovery-swarm sets `swarm._listening` synchronously and waits for the nextTick to try to listen after a `.join()`.

cc @mafintosh @juliangruber (re: #23)